### PR TITLE
Fix path issue with `csvtojson` command

### DIFF
--- a/scripts/CsvToJson.js
+++ b/scripts/CsvToJson.js
@@ -1,4 +1,5 @@
 const Base = require('./Base.js');
+const path = require('path');
 const exec = require('child_process').exec;
 
 class CsvToJsonScript extends Base {
@@ -23,7 +24,7 @@ class CsvToJsonScript extends Base {
 
     // Execute external CSV to JSON module
     exec(
-      `./node_modules/csvtojson/bin/csvtojson ${sourceFilepath} > ${outputFilepath}`,
+      `${path.join(__dirname, '../node_modules/csvtojson/bin/csvtojson')} ${sourceFilepath} > ${outputFilepath}`,
       (err, stdout, stderr) => {
         if (err) throw err;
         console.log(`stdout: ${stdout}`, `stderr: ${stderr}`);


### PR DESCRIPTION
When issuing the `csvtojson` command, I ran into the following issue:

```
❯ algolia csvtojson -s MY_INPUT.csv -o MY_OUTPUT.json
/usr/local/lib/node_modules/@algolia/cli/scripts/CsvToJson.js:28
        if (err) throw err;
                 ^

Error: Command failed: ./node_modules/csvtojson/bin/csvtojson ./MY_INPUT.csv > MY_OUTPUT.json
/bin/sh: ./node_modules/csvtojson/bin/csvtojson: No such file or directory

    at ChildProcess.exithandler (child_process.js:275:12)
    at emitTwo (events.js:126:13)
    at ChildProcess.emit (events.js:214:7)
    at maybeClose (internal/child_process.js:925:16)
    at Socket.stream.socket.on (internal/child_process.js:346:11)
    at emitOne (events.js:116:13)
    at Socket.emit (events.js:211:7)
    at Pipe._handle.close [as _onclose] (net.js:567:12)
```

The issue seems to come from the `CsvToJson` script using relative path from the place the script is called. Using `__dirname` solves this, which is what this PR is all about. :)