### PR TITLE
chore(setup): make simpler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,6 @@ install:
 script:
 - yarn lint
 - yarn jest
-branches:
-  only:
-  - master
-  - develop
 cache:
   yarn: true
 notifications:

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-test: npm run jest

--- a/package.json
+++ b/package.json
@@ -13,10 +13,9 @@
     "algolia": "./index.js"
   },
   "scripts": {
-    "test": "nf start test",
-    "test:unit": "node_modules/.bin/jest /scripts/",
-    "test:unit:watch": "node_modules/.bin/jest --watch /scripts/",
-    "jest": "node_modules/.bin/jest --runInBand --forceExit",
+    "test": "jest --runInBand --forceExit",
+    "test:unit": "jest /scripts/",
+    "test:unit:watch": "jest --watch /scripts/",
     "lint": "eslint . --ext .js",
     "lint:fix": "npm run lint -- --fix"
   },

--- a/readme.md
+++ b/readme.md
@@ -381,7 +381,6 @@ $ algolia transferindexconfig -a EXAMPLE_SOURCE_APP_ID -k EXAMPLE_SOURCE_API_KEY
 
 - Node: `brew install node` or [Node docs](https://nodejs.org/en/)
 - Yarn: `brew install yarn` or [Yarn docs](https://yarnpkg.com/lang/en/)
-- Foreman: `npm i -g foreman` or [Foreman docs](https://www.npmjs.com/package/foreman)
 
 ## Install
 
@@ -404,7 +403,7 @@ $ algolia transferindexconfig -a EXAMPLE_SOURCE_APP_ID -k EXAMPLE_SOURCE_API_KEY
 - `yarn test` to run full test suite locally
 - `yarn test:unit` to run unit test suite only
 - `yarn test:unit:watch` to run unit test suite with interactive `--watch` flag
-- `yarn jest` to run full test suite in staging environment with pre-set environment variables (eg. Travis)
+- `yarn test` to run full test suite in staging environment with pre-set environment variables (eg. Travis)
 
 ## Lint
 - `yarn lint` to run eslint


### PR DESCRIPTION
1. no need for foreman if it's just an package.json script
2. node_modules/.bin is not necessary in package scripts