### PR TITLE
Release/3.1.2

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ program
   )
   .option(
     '-p, --params <params>',
-    'Optional params to pass to dependency (eg. <csvToJsonParams> or <algoliaParams>) | Optional for: "import" and "export" commands'
+    'Optional params to pass to dependency (eg. <csvToJsonParams>, <algoliaParams>, or <configParams>) | Optional for: "import", "export", and "transferindexconfig" commands'
   )
   .option(
     '-m, --maxconcurrency <maxConcurrency>',
@@ -78,7 +78,7 @@ Commands:
   6. setsettings -a <algoliaAppId> -k <algoliaApiKey> -n <algoliaIndexName> -s <sourceFilepath>
 
   7. transferindex -a <sourceAlgoliaAppId> -k <sourceAlgoliaApiKey> -n <sourceAlgoliaIndexName> -d <destinationAlgoliaAppId> -y <destinationAlgoliaApiKey> -t <transformationFilepath>
-  8. transferindexconfig -a <sourceAlgoliaAppId> -k <sourceAlgoliaApiKey> -n <sourceAlgoliaIndexName> -d <destinationAlgoliaAppId> -y <destinationAlgoliaApiKey>
+  8. transferindexconfig -a <sourceAlgoliaAppId> -k <sourceAlgoliaApiKey> -n <sourceAlgoliaIndexName> -d <destinationAlgoliaAppId> -y <destinationAlgoliaApiKey> -p <configParams>
 
   9. transformlines -s <sourceFilepath> -o <outputFilepath> -t <transformationFilepath>
   10. csvtojson -s <sourceFilepath> -o <outputFilepath> <csvToJsonParams>
@@ -92,7 +92,7 @@ Examples:
   $ algolia getsettings -a EXAMPLE_APP_ID -k EXAMPLE_API_KEY -n EXAMPLE_INDEX_NAME
   $ algolia setsettings -a EXAMPLE_APP_ID -k EXAMPLE_API_KEY -n EXAMPLE_INDEX_NAME -s ~/Desktop/example_settings.js
   $ algolia transferindex -a EXAMPLE_SOURCE_APP_ID -k EXAMPLE_SOURCE_API_KEY -n EXAMPLE_SOURCE_INDEX_NAME -d EXAMPLE_DESTINATION_APP_ID -y EXAMPLE_DESTINATION_API_KEY -t ~/Desktop/example_transformations.js
-  $ algolia transferindexconfig -a EXAMPLE_SOURCE_APP_ID -k EXAMPLE_SOURCE_API_KEY -n EXAMPLE_SOURCE_INDEX_NAME -d EXAMPLE_DESTINATION_APP_ID -y EXAMPLE_DESTINATION_API_KEY
+  $ algolia transferindexconfig -a EXAMPLE_SOURCE_APP_ID -k EXAMPLE_SOURCE_API_KEY -n EXAMPLE_SOURCE_INDEX_NAME -d EXAMPLE_DESTINATION_APP_ID -y EXAMPLE_DESTINATION_API_KEY -p '{"batchSynonymsParams":{"forwardToReplicas":true}}'
   $ algolia transformlines -s ~/Desktop/example_source.json -o ~/Desktop/example_output.json -t ~/Desktop/example_transformations.js
 `;
     console.log(message);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@algolia/cli",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "A Node CLI tools for manipulating data. Handy for day-to-day Algolia SE work.",
   "license": "ISC",
   "author": "Sepehr Fakour",

--- a/readme.md
+++ b/readme.md
@@ -37,7 +37,7 @@ $ algolia setsettings -a <algoliaAppId> -k <algoliaApiKey> -n <algoliaIndexName>
 
 $ algolia transferindex -a <sourcealgoliaAppId> -k <sourcealgoliaApiKey> -n <sourcealgoliaIndexName> -d <destinationAlgoliaAppId> -y <destinationAlgoliaApiKey> -t <transformationFilepath>
 
-$ algolia transferindexconfig -a <sourcealgoliaAppId> -k <sourcealgoliaApiKey> -n <sourcealgoliaIndexName> -d <destinationAlgoliaAppId> -y <destinationAlgoliaApiKey>
+$ algolia transferindexconfig -a <sourcealgoliaAppId> -k <sourcealgoliaApiKey> -n <sourcealgoliaIndexName> -d <destinationAlgoliaAppId> -y <destinationAlgoliaApiKey> -p <configParams>
 
 $ algolia transformlines -s <sourceFilepath> -o <outputFilepath> -t <transformationFilepath>
 ```
@@ -107,7 +107,7 @@ algolia import -s <sourceFilepath> -a <algoliaAppId> -k <algoliaApiKey> -n <algo
 - `<batchSize>` | Optional | Number of JSON objects to be included in each batch for indexing. Default is `5000`.
 - `<transformationFilepath>` | Optional | The path to any file that exports a function which (1) takes 2 arguments; an object and a callback, then (2) ends by calling said callback with the 2 arguments `null` and `<YOUR_TRANSFORMED_OBJECT>`.
 - `<maxConcurrency>` | Optional | Maximum number of concurrent filestreams to process. Default is `2`.
-- `<csvToJsonParams>` | Optional | [Parser parameters](https://github.com/Keyang/node-csvtojson#parameters) passed to [csvtojson](https://www.npmjs.com/package/csvtojson) module.
+- `<csvToJsonParams>` | Optional | Stringified [Parser parameters](https://github.com/Keyang/node-csvtojson#parameters) object passed to [csvtojson](https://www.npmjs.com/package/csvtojson) module.
 
 ##### Example Transformation File:
 
@@ -149,7 +149,7 @@ algolia export -a <algoliaAppId> -k <algoliaApiKey> -n <algoliaIndexName> -o <ou
 - `<algoliaApiKey>` | Required
 - `<algoliaIndexName>` | Required
 - `<outputFilepath>` | Required | Must be an existing local directory.
-- `<algoliaParams>` | Optional | [Search params](https://www.algolia.com/doc/api-reference/search-api-parameters/) to be sent with `browseAll()` query to Algolia.
+- `<algoliaParams>` | Optional | Stringified [Search params](https://www.algolia.com/doc/api-reference/search-api-parameters/) object to be sent with `browseAll()` query to Algolia.
 
 ### 5. Get Settings | `getsettings`
 
@@ -262,7 +262,7 @@ Transfer an index's settings, synonyms, and query rules to another index. Works 
 ##### Usage:
 
 ```shell
-algolia transferindexconfig -a <sourceAlgoliaAppId> -k <sourceAlgoliaApiKey> -n <sourceAlgoliaIndexName> -d <destinationAlgoliaAppId> -y <destinationAlgoliaApiKey>
+algolia transferindexconfig -a <sourceAlgoliaAppId> -k <sourceAlgoliaApiKey> -n <sourceAlgoliaIndexName> -d <destinationAlgoliaAppId> -y <destinationAlgoliaApiKey> -p <configParams>
 ```
 
 ##### Options:
@@ -272,10 +272,11 @@ algolia transferindexconfig -a <sourceAlgoliaAppId> -k <sourceAlgoliaApiKey> -n 
 - `<sourceAlgoliaIndexName>` | Required
 - `<destinationAlgoliaAppId>` | Required
 - `<destinationAlgoliaApiKey>` | Required
+- `<configParams>` | Optional | Stringified object containing one or both of the following two properties: `batchSynonymsParams` and `batchRulesParams`. Each of those property values may contain a parameters object to be passed to the [batchSynonyms](https://www.algolia.com/doc/api-reference/api-methods/batch-synonyms/) and [batchRules](https://www.algolia.com/doc/api-reference/api-methods/batch-rules/) respectively.
 
 ##### Notes:
 
-- When transferring synonyms and query rules: `forwardToReplicas`, `replaceExistingSynonyms`, and `clearExistingRules` params will be set to true.
+- When transferring synonyms and query rules, `forwardToReplicas`, `replaceExistingSynonyms`, and `clearExistingRules` params will default to false, unless you specify `<configParams>`.
 
 ### 9. Transform Lines | `transformlines`
 
@@ -348,7 +349,7 @@ $ algolia setsettings -a EXAMPLE_APP_ID -k EXAMPLE_API_KEY -n EXAMPLE_INDEX_NAME
 
 $ algolia transferindex -a EXAMPLE_SOURCE_APP_ID -k EXAMPLE_SOURCE_API_KEY -n EXAMPLE_SOURCE_INDEX_NAME -d EXAMPLE_DESTINATION_APP_ID -y EXAMPLE_DESTINATION_API_KEY -t ~/Desktop/example_transformations.js
 
-$ algolia transferindexconfig -a EXAMPLE_SOURCE_APP_ID -k EXAMPLE_SOURCE_API_KEY -n EXAMPLE_SOURCE_INDEX_NAME -d EXAMPLE_DESTINATION_APP_ID -y EXAMPLE_DESTINATION_API_KEY
+$ algolia transferindexconfig -a EXAMPLE_SOURCE_APP_ID -k EXAMPLE_SOURCE_API_KEY -n EXAMPLE_SOURCE_INDEX_NAME -d EXAMPLE_DESTINATION_APP_ID -y EXAMPLE_DESTINATION_API_KEY -p '{"batchSynonymsParams":{"forwardToReplicas":true,"replaceExistingSynonyms":true},"batchRulesParams":{"forwardToReplicas":true,"clearExistingRules":true}}'
 ```
 
 # Contribute

--- a/scripts/TransferIndexConfig.js
+++ b/scripts/TransferIndexConfig.js
@@ -55,21 +55,14 @@ class TransferIndexConfigScript extends Base {
       this.rOptions = configParams.batchRulesParams;
   }
 
-  transferIndexConfig() {
-    return new Promise(async (resolve, reject) => {
-      try {
-        // Transfer settings, synonyms, and query rules
-        const settings = await this.sourceIndex.getSettings();
-        const synonyms = await this.sourceIndex.exportSynonyms();
-        const rules = await this.sourceIndex.exportRules();
-        await this.destinationIndex.setSettings(settings);
-        await this.destinationIndex.batchSynonyms(synonyms, this.sOptions);
-        await this.destinationIndex.batchRules(rules, this.rOptions);
-        return resolve();
-      } catch (e) {
-        return reject(e);
-      }
-    });
+  async transferIndexConfig() {
+    // Transfer settings, synonyms, and query rules
+    const settings = await this.sourceIndex.getSettings();
+    const synonyms = await this.sourceIndex.exportSynonyms();
+    const rules = await this.sourceIndex.exportRules();
+    await this.destinationIndex.setSettings(settings);
+    await this.destinationIndex.batchSynonyms(synonyms, this.sOptions);
+    await this.destinationIndex.batchRules(rules, this.rOptions);
   }
 
   async start(program) {

--- a/scripts/TransferIndexConfig.js
+++ b/scripts/TransferIndexConfig.js
@@ -65,9 +65,9 @@ class TransferIndexConfigScript extends Base {
         await this.destinationIndex.setSettings(settings);
         await this.destinationIndex.batchSynonyms(synonyms, this.sOptions);
         await this.destinationIndex.batchRules(rules, this.rOptions);
-        resolve();
+        return resolve();
       } catch (e) {
-        reject(e);
+        return reject(e);
       }
     });
   }

--- a/scripts/TransferIndexConfig.unit.test.js
+++ b/scripts/TransferIndexConfig.unit.test.js
@@ -53,6 +53,44 @@ describe('Transfer Index script OK', () => {
     done();
   });
 
+  /* setConfigOptions */
+
+  test('setConfigOptions should set default params for batchSynonyms and batchRules', done => {
+    const mockOptions = {
+      configParams: undefined,
+    };
+    const result = transferIndexConfigScript.setConfigOptions(mockOptions);
+    expect(result).toEqual(undefined);
+    expect(transferIndexConfigScript.sOptions).toEqual(expect.any(Object));
+    expect(transferIndexConfigScript.rOptions).toEqual(expect.any(Object));
+    done();
+  });
+
+  test('setConfigOptions should set input params for batchSynonyms and batchRules', done => {
+    const configParams = {
+      batchSynonymsParams: {
+        forwardToReplicas: true,
+        replaceExistingSynonyms: true,
+      },
+      batchRulesParams: {
+        forwardToReplicas: true,
+        clearExistingRules: true,
+      },
+    };
+    const mockOptions = {
+      configParams: JSON.stringify(configParams),
+    };
+    const result = transferIndexConfigScript.setConfigOptions(mockOptions);
+    expect(result).toEqual(undefined);
+    expect(transferIndexConfigScript.sOptions).toEqual(
+      configParams.batchSynonymsParams
+    );
+    expect(transferIndexConfigScript.rOptions).toEqual(
+      configParams.batchRulesParams
+    );
+    done();
+  });
+
   /* transferIndexConfig */
 
   test('transferIndexConfig should set algolia clients and indices', async done => {
@@ -90,7 +128,7 @@ describe('Transfer Index script OK', () => {
 
   /* start */
 
-  test('Services should be called with valid params', done => {
+  test('Services should be called with valid params', async done => {
     global.console.log = jest.fn();
 
     // Mock Algolia
@@ -114,7 +152,7 @@ describe('Transfer Index script OK', () => {
     algolia.mockReturnValue(client);
 
     // Execute method
-    const result = transferIndexConfigScript.start(validProgram);
+    const result = await transferIndexConfigScript.start(validProgram);
 
     // Use timeout to defer execution of test assertions
     setTimeout(() => {
@@ -142,7 +180,7 @@ describe('Transfer Index script OK', () => {
     }, 0);
   });
 
-  test('Transfer Index Config catches exceptions', done => {
+  test('Transfer Index Config catches exceptions', async done => {
     const message = 'fgctry6y7u8ioj';
     try {
       // Mock error during execution
@@ -150,7 +188,7 @@ describe('Transfer Index script OK', () => {
         throw new Error(message);
       });
       // Execute method
-      transferIndexConfigScript.start(validProgram);
+      await transferIndexConfigScript.start(validProgram);
       throw new Error('This error should not be reached');
     } catch (e) {
       expect(e.message).toEqual(message);

--- a/tests/integration/TransferIndexConfig.integration.test.js
+++ b/tests/integration/TransferIndexConfig.integration.test.js
@@ -47,7 +47,7 @@ describe('TransferIndexConfig command OK', () => {
 
   test(
     'TransferIndexConfig moves settings, synonyms, and rules',
-    done => {
+    async done => {
       const endMsg =
         'Index settings, synonyms, and query rules transferred successfully.';
 
@@ -69,7 +69,7 @@ describe('TransferIndexConfig command OK', () => {
       });
 
       // Execute transfer
-      transferIndexConfigScript.start(validProgram);
+      await transferIndexConfigScript.start(validProgram);
     },
     60000
   );


### PR DESCRIPTION
- Allow user to specify `batchSynonyms` and `batchRules` Algolia method params, otherwise use defaults
- TransferIndexConfig only displays success message if all of settings, synonyms, and rules are transferred
- Add tests
- Update docs