### PR TITLE
Patch to support Linux

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node --max_old_space_size=4096
+#!/usr/bin/env node
 
 const program = require('commander');
 const { version } = require('./package.json');
@@ -16,7 +16,7 @@ const addSynonymsScript = require('./scripts/AddSynonyms.js');
 const exportRulesScript = require('./scripts/ExportRules.js');
 const exportSynonymsScript = require('./scripts/ExportSynonyms.js');
 const transferIndexScript = require('./scripts/TransferIndex.js');
-const transferIndexConfigScript = require('./scripts/transferIndexConfig.js');
+const transferIndexConfigScript = require('./scripts/TransferIndexConfig.js');
 const transformLinesScript = require('./scripts/TransformLines.js');
 const deleteIndicesPatternScript = require('./scripts/DeleteIndicesPattern.js');
 

--- a/scripts/TransferIndex.js
+++ b/scripts/TransferIndex.js
@@ -20,13 +20,13 @@ class TransferIndexScript extends Base {
     this.start = this.start.bind(this);
     // Define validation constants
     this.message =
-      '\nExample: $ algolia transferindex -a sourcealgoliaappid -k sourcealgoliaapikey -n sourcealgoliaindexname -d destinationalgoliaappid -y destinationalgoliaapikey -i destinationindexname -t transformationfilepath\n\n';
+      '\nExample: $ algolia transferindex -a sourceAlgoliaAppId -k sourceAlgoliaApiKey -n sourceAlgoliaIndexName -d destinationAlgoliaAppId -y destinationAlgoliaApiKey -i destinationIndexName -t transformationfilepath\n\n';
     this.params = [
-      'algoliaappid',
-      'algoliaapikey',
-      'algoliaindexname',
-      'destinationalgoliaappid',
-      'destinationalgoliaapikey',
+      'sourceAlgoliaAppId',
+      'sourceAlgoliaApiKey',
+      'sourceAlgoliaIndexName',
+      'destinationAlgoliaAppId',
+      'destinationAlgoliaApiKey',
     ];
   }
 
@@ -110,13 +110,13 @@ class TransferIndexScript extends Base {
 
       // Config params
       const options = {
-        sourceAppId: program.algoliaappid,
-        sourceApiKey: program.algoliaapikey,
-        sourceIndexName: program.algoliaindexname,
-        destinationAppId: program.destinationalgoliaappid,
-        destinationApiKey: program.destinationalgoliaapikey,
+        sourceAppId: program.sourceAlgoliaAppId,
+        sourceApiKey: program.sourceAlgoliaApiKey,
+        sourceIndexName: program.sourceAlgoliaIndexName,
+        destinationAppId: program.destinationAlgoliaAppId,
+        destinationApiKey: program.destinationAlgoliaApiKey,
         destinationIndexName:
-          program.destinationindexname || program.algoliaindexname,
+          program.destinationIndexName || program.sourceAlgoliaIndexName,
         transformations: program.transformationfilepath || null,
       };
 


### PR DESCRIPTION
This is a patch in order support running of the `cli` on Linux.

It basically fixes following issues:
- env on linux can't take extra variable arguments (see: https://unix.stackexchange.com/a/63981 for instance)
- case sensitivity of `scripts/TransferIndexConfig.js` (doesn't work on case sensitive filesystems)
- arguments to transfer index are mismatched

Credits to **Jason Crowe @ hatched** for all the details.