### PR TITLE
Make the transfer index command work

### DIFF
--- a/commands/TransferIndex.js
+++ b/commands/TransferIndex.js
@@ -12,7 +12,7 @@ class TransferIndexScript extends Base {
     this.start = this.start.bind(this);
     // Define validation constants
     this.message =
-      '\nExample: $ algolia transferindex -a sourcealgoliaappid -k sourcealgoliaapikey -n sourcealgoliaindexname -d destinationalgoliaappid -y destinationalgoliaapikey -i destinationindexname -t transformationfilepath\n\n';
+      '\nExample: $ algolia transferindex -a algoliaappid -k algoliaapikey -n algoliaindexname -d destinationalgoliaappid -y destinationalgoliaapikey -i destinationindexname -t transformationfilepath\n\n';
     this.params = [
       'sourcealgoliaappid',
       'sourcealgoliaapikey',

--- a/index.js
+++ b/index.js
@@ -223,16 +223,10 @@ program
   .description(
     'Duplicate the data and settings of an index from one Algolia App to another'
   )
+  .option('-a, --algoliaappid <algoliaAppId>', 'Required | Algolia app ID')
+  .option('-k, --algoliaapikey <algoliaApiKey>', 'Required | Algolia API key')
   .option(
-    '-a, --sourcealgoliaappid <algoliaAppId>',
-    'Required | Algolia app ID'
-  )
-  .option(
-    '-k, --sourcealgoliaapikey <algoliaApiKey>',
-    'Required | Algolia API key'
-  )
-  .option(
-    '-n, --sourcealgoliaindexname <algoliaIndexName>',
+    '-n, --algoliaindexname <algoliaIndexName>',
     'Required | Algolia index name'
   )
   .option(


### PR DESCRIPTION
I tried to run the `transfer index` command after cloning this repository, but I couldn't make it work. It seems like there is a naming issue inside the `index.js` file. After making these changes `transfer index` works as long as the two indices are on separate clusters.