### PR TITLE
Fix typo in the shorthand for export rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -153,7 +153,7 @@ program
 // Add Rules
 program
   .command('addrules')
-  .alias('er')
+  .alias('ar')
   .description('Add query rules to an Algolia index from a JSON file')
   .option('-a, --algoliaappid <algoliaAppId>', 'Required | Algolia app ID')
   .option('-k, --algoliaapikey <algoliaApiKey>', 'Required | Algolia API key')


### PR DESCRIPTION
This typo causes `node . er` to not work properly