### PR TITLE
Delete the replicas key from the settings object before making setSettings API call

### DIFF
--- a/commands/TransferIndexConfig.js
+++ b/commands/TransferIndexConfig.js
@@ -59,7 +59,7 @@ class TransferIndexConfigScript extends Base {
   async transferIndexConfig(indices, config) {
     // Transfer settings, synonyms, and query rules
     const settings = await indices.sourceIndex.getSettings();
-    delete settings['replicas'];
+    delete settings.replicas;
     const synonyms = await indices.sourceIndex.exportSynonyms();
     const rules = await indices.sourceIndex.exportRules();
     await indices.destinationIndex.setSettings(settings);

--- a/commands/TransferIndexConfig.js
+++ b/commands/TransferIndexConfig.js
@@ -59,6 +59,7 @@ class TransferIndexConfigScript extends Base {
   async transferIndexConfig(indices, config) {
     // Transfer settings, synonyms, and query rules
     const settings = await indices.sourceIndex.getSettings();
+    delete settings['replicas'];
     const synonyms = await indices.sourceIndex.exportSynonyms();
     const rules = await indices.sourceIndex.exportRules();
     await indices.destinationIndex.setSettings(settings);


### PR DESCRIPTION
This key can't be copied over to the destination index. It should be dropped _before_ making the `setSettings()` API call.