### PR TITLE
Transfer Index command won't work when trying to copy from an index with replicas

### DIFF
--- a/commands/TransferIndex.js
+++ b/commands/TransferIndex.js
@@ -8,7 +8,7 @@ class TransferIndexScript extends Base {
     this.getIndices = this.getIndices.bind(this);
     this.getTransformations = this.getTransformations.bind(this);
     this.transferIndexConfig = this.transferIndexConfig.bind(this);
-    this.transferData = this.transferData.bind(this);
+      this.transferData = this.transferData.bind(this);
     this.start = this.start.bind(this);
     // Define validation constants
     this.message =
@@ -48,11 +48,12 @@ class TransferIndexScript extends Base {
     return valid ? transformations : null;
   }
 
-  async transferIndexConfig(indices) {
+  async transferIndexConfig(indices, options) {
     // Transfer settings, synonyms, and query rules
     const settings = await indices.sourceIndex.getSettings();
     const synonyms = await indices.sourceIndex.exportSynonyms();
     const rules = await indices.sourceIndex.exportRules();
+    if (options.excludeReplicas) delete settings.replicas;
     await indices.destinationIndex.setSettings(settings);
     await indices.destinationIndex.batchSynonyms(synonyms);
     await indices.destinationIndex.batchRules(rules);
@@ -99,6 +100,10 @@ class TransferIndexScript extends Base {
         destinationIndexName:
           program.destinationindexname || program.sourcealgoliaindexname,
         transformations: program.transformationfilepath || null,
+        excludeReplicas:
+          program.excludereplicas !== undefined
+            ? program.excludereplicas === 'true'
+            : false,
       };
 
       // Configure Algolia clients/indices
@@ -106,7 +111,7 @@ class TransferIndexScript extends Base {
       // Configure transformations
       const formatRecord = this.getTransformations(options);
       // Transfer index configuration
-      await this.transferIndexConfig(indices);
+      await this.transferIndexConfig(indices, options);
       // Transfer data
       const result = await this.transferData(indices, formatRecord);
 

--- a/commands/TransferIndex.unit.test.js
+++ b/commands/TransferIndex.unit.test.js
@@ -85,8 +85,13 @@ describe('Transfer Index script OK', () => {
       },
     };
 
+    // Mock options
+    const options = {
+      excludeReplicas: true,
+    };
+
     // Execute transfer
-    await transferIndexScript.transferIndexConfig(indices);
+    await transferIndexScript.transferIndexConfig(indices, options);
     expect(getSettings).toHaveBeenCalled();
     expect(exportSynonyms).toHaveBeenCalled();
     expect(exportRules).toHaveBeenCalled();
@@ -203,6 +208,7 @@ describe('Transfer Index script OK', () => {
       destinationApiKey: validProgram.destinationalgoliaapikey,
       destinationIndexName: validProgram.destinationindexname,
       transformations: null,
+      excludeReplicas: false,
     };
     // Mock instance methods
     transferIndexScript.getIndices = jest.fn(() => 'indices');
@@ -217,7 +223,10 @@ describe('Transfer Index script OK', () => {
     expect(transferIndexScript.getTransformations).toHaveBeenCalledWith(
       options
     );
-    expect(transferIndexScript.transferIndexConfig).toHaveBeenCalled();
+    expect(transferIndexScript.transferIndexConfig).toHaveBeenCalledWith(
+      'indices',
+      options
+    );
     expect(transferIndexScript.transferData).toHaveBeenCalledWith(
       'indices',
       'transformations'

--- a/index.js
+++ b/index.js
@@ -251,6 +251,10 @@ program
     '-t, --transformationfilepath <transformationFilepath>',
     'Optional | Transformation filepath'
   )
+  .option(
+    '-e, --excludereplicas <boolean>',
+    'Optional | Exclude replicas property of settings object'
+  )
   .action(cmd => {
     commands.transferindex.start(cmd);
   });


### PR DESCRIPTION
`transferIndex` command doesn't work when the source is a primary index with replicas because the setSettings payload has a replicas parameter.

The implementation is based on the transferindexconfig command: https://github.com/algolia/algolia-cli/blob/develop/commands/TransferIndexConfig.js#L64.

Related to https://github.com/algolia/algolia-cli/issues/36.